### PR TITLE
parse_dds_security_part: make `ROS_SECURITY_ENCLAVE_OVERRIDE` optional

### DIFF
--- a/parse_dds_security_part.py
+++ b/parse_dds_security_part.py
@@ -15,8 +15,8 @@ if env_keystore is None:
   sys.exit(0)
 
 if env_enclave_override is None:
-  print("ERROR: environment variable 'ROS_SECURITY_ENCLAVE_OVERRIDE' not found")
-  sys.exit(-1)
+  # this is not required at ROS side either. this empty path component later used in `os.path.join()` yields correct path.
+  env_enclave_override = ""
 
 # Remove backslash from beginning of override path to avoid os.path.join to
 #  start over from the root


### PR DESCRIPTION
fog-hyper no longer supplies this so this caused the container to "crash".

Nor should this be required since at ROS side ([RCL)](https://github.com/ros2/rcl/blob/b4e6e140bc2209ce01d8d47a77393e8549133020/rcl/src/rcl/security.c#L181-L187) it's optional too.