### PR TITLE
Bump tiiuae/fog-ros-baseimage from v3.3.0 to v3.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Given dynamically from CI job.
-FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:v3.3.0-${TARGETARCH:-amd64} AS builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:v3.4.0-${TARGETARCH:-amd64} AS builder
 
 # Must be defined another time after "FROM" keyword.
 ARG TARGETARCH
@@ -16,7 +16,7 @@ RUN /packaging/build_colcon_sdk.sh ${TARGETARCH:-amd64}
 #  ▲               runtime ──┐
 #  └── build                 ▼
 
-FROM ghcr.io/tiiuae/fog-ros-baseimage:v3.3.0
+FROM ghcr.io/tiiuae/fog-ros-baseimage:v3.4.0
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 

--- a/agent.refs
+++ b/agent.refs
@@ -1,8 +1,8 @@
 <profiles>
-    <participant profile_name="default_xrce_participant">
+    <participant profile_name="px4_participant">
         <domainId>0</domainId>
         <rtps>
-            <name>default_xrce_participant</name>
+            <name>px4_participant</name>
         </rtps>
     </participant>
 </profiles>

--- a/combine_default_profiles.py
+++ b/combine_default_profiles.py
@@ -3,6 +3,8 @@
 import sys, os, re
 import shutil
 
+participant_profile_name="px4_participant"
+
 agent_refs_path=""
 if len(sys.argv) > 1:
   agent_refs_path=sys.argv[1]
@@ -38,10 +40,12 @@ with open(default_profiles_file, "r") as in_f:
       line_str = line.strip()
 
       # Replace participant profile name
+      search_str = 'profile_name="\S+"'
+      replace_str = 'profile_name="'+participant_profile_name+'"'
       if line_str.startswith("<participant") and "profile_name=" in line_str:
         line = re.sub(
-            'profile_name="\S+"',
-            'profile_name="default_xrce_participant"',
+            search_str,
+            replace_str,
             line)
 
       # Remove data_reader and data_writer configs

--- a/parse_dds_security_part.py
+++ b/parse_dds_security_part.py
@@ -14,16 +14,17 @@ if env_keystore is None:
   print("environment variable 'ROS_SECURITY_KEYSTORE' not set")
   sys.exit(0)
 
-if env_enclave_override is None:
-  # this is not required at ROS side either. this empty path component later used in `os.path.join()` yields correct path.
-  env_enclave_override = ""
+enclave_path=env_keystore
 
-# Remove backslash from beginning of override path to avoid os.path.join to
-#  start over from the root
-if env_enclave_override.startswith("/"):
-  env_enclave_override = env_enclave_override[1:]
+if env_enclave_override is not None:
+  # Remove backslash from beginning of override path to avoid os.path.join to
+  #  start over from the root
+  if env_enclave_override.startswith("/"):
+    env_enclave_override = env_enclave_override[1:]
+  # Legacy implementation
+  enclave_path = os.path.join(env_keystore, "enclaves", env_enclave_override)
 
-enclave_path = os.path.join(env_keystore, "enclaves", env_enclave_override)
+print("Using enclave path: " + enclave_path)
 key_path = os.path.join(enclave_path, "key.p11")
 
 if not os.path.exists(key_path):


### PR DESCRIPTION
Update fog-ros-baseimage from sha-c04d413 to v3.4.0
This PR is auto generated by a remote workflow.
Message from author of this PR;
**PX4-MSGS Upgraded to v7.0.0**
